### PR TITLE
fix Muse menu drop down layout

### DIFF
--- a/source/css/_schemes/Muse/_menu.styl
+++ b/source/css/_schemes/Muse/_menu.styl
@@ -8,6 +8,7 @@
     padding: 0;
     background: white;
     border-bottom: 1px solid $gray-lighter;
+    z-index: 1;
   }
 }
 


### PR DESCRIPTION
在站点配置文件中设置总计超过6个首页菜单项目（归档、标签、关于、搜索等），然后切换至移动/平板布局下，点击页面上方的汉堡菜单时，会无法遮挡文章标题内容而出现菜单文字混淆覆盖的问题，可以简单修复一下

![](http://7xsf4p.com1.z0.glb.clouddn.com/images/screenshot/%E5%B1%8F%E5%B9%95%E5%BF%AB%E7%85%A7%202016-11-16%20%E4%B8%8A%E5%8D%889.33.42.png)